### PR TITLE
fix(fetch): don't create a folder when the repo can't be found (#1)

### DIFF
--- a/src/fetch_cmd.py
+++ b/src/fetch_cmd.py
@@ -3,6 +3,7 @@ import os
 import json
 import shutil
 import pathlib
+import zipfile
 
 from cli_cmd import cli, zipapp_dir
 #from urllib.request import urlretrieve
@@ -25,15 +26,24 @@ def fetch_cmd(repo, user, branch, folder, overwrite_libs, skip_libs, skip_clean,
     skip_unzip = False
     skip_remove = False
 
-    # Retrieve the file from github
-    try:
-        if not skip_repo:
-            curlretrieve(url, zip_file_path)
-    except Exception as e:
-        print(f"ERROR: BAD MISSION URL: {url}")
-        return
-    
-    # If we got here we have a folder
+    # Retrieve the file from github.
+    # Do NOT create/clean any destination folder until we are sure we actually
+    # downloaded a real zip -- a typo in the repo name must not leave an empty
+    # folder behind (issue #1).
+    if not skip_repo:
+        ok = False
+        try:
+            ok = curlretrieve(url, zip_file_path)
+        except Exception as e:
+            ok = False
+        if not ok or not zipfile.is_zipfile(zip_file_path):
+            print(f"ERROR: BAD MISSION URL: {url}")
+            print(f"       Could not find repository '{repo}' for user '{user}' (branch '{branch}').")
+            if os.path.exists(zip_file_path):
+                os.remove(zip_file_path)
+            return
+
+    # If we got here we have a valid zip
     # Get dependencies by processing story.json
     destination_directory = folder if folder is not None else repo
     working_directory = zipapp_dir

--- a/src/file_help.py
+++ b/src/file_help.py
@@ -9,29 +9,37 @@ import os
 # "https://github.com/%USER%/%REPO%/zipball/%BRANCH%/"
 
 def curlretrieve(url, localname):
-    """Usew curl to retreive the files
+    """Use curl to retrieve the files
 
     Args:
         url (str): the url
         localname (str): The local filename
+
+    Returns:
+        bool: True if the file was downloaded successfully, False otherwise.
     """
     import subprocess
 
     # Recommended way to run a command and capture output
     try:
+        # -f/--fail makes curl exit non-zero on HTTP errors (e.g. 404) instead
+        # of quietly writing the error page (like GitHub's 404 HTML) to disk.
         result = subprocess.run(
-            ["curl","-L", "--max-redirs", "5", f"{url}", "--output", localname],  # Command and arguments as a list
+            ["curl", "-f", "-L", "--max-redirs", "5", f"{url}", "--output", localname],  # Command and arguments as a list
             capture_output=True,   # Capture stdout and stderr
             text=True,             # Return strings instead of bytes
             check=True             # Raise exception on non-zero exit
         )
         print("Command ran successfully.")
         print(result.stdout)
+        return True
     except subprocess.CalledProcessError as e:
         print(f"Command failed with return code {e.returncode}")
         print(e.stderr)
+        return False
     except FileNotFoundError:
         print("Command not found.")
+        return False
 
 
 def zipdir(folder_path, zip_file_name, first_folder=None):

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,43 @@
+# sbs_cli tests
+
+Plain-stdlib `unittest` (no pytest, no extra deps). Run from the repo root:
+
+```
+python -m unittest discover -s tests
+python -m unittest discover -s tests -v      # verbose
+python -m unittest tests.test_fetch_cmd      # one module
+```
+
+`tests/_bootstrap.py` puts `src/` on `sys.path` (the modules use flat absolute
+imports like `from file_help import curlretrieve`); import it first in every
+test file.
+
+## Mocking instead of real downloads
+
+No test hits the network or shells out to `curl`. Three seams, from lowest to
+highest level:
+
+| Seam | Patch | Use it to test |
+|---|---|---|
+| `subprocess.run` | `mock.patch.object(subprocess, "run", ...)` | `curlretrieve` itself — that it returns True/False and passes `-f` |
+| `curlretrieve` | `mock.patch.object(fetch_cmd, "curlretrieve", fake)` | `fetch_cmd` logic — the fake writes a real in-memory zip (or nothing) to `localname` |
+| whole command | `click.testing.CliRunner().invoke(cli, [...])` | the Click layer end-to-end (options, prompts) |
+
+**Patch where the name is looked up.** `fetch_cmd` does
+`from file_help import curlretrieve`, so it has its *own* `fetch_cmd.curlretrieve`
+binding — patch that, not `file_help.curlretrieve`.
+
+**Redirect the filesystem.** `fetch` cleans/creates folders relative to
+`zipapp_dir` (and the CWD). Tests patch `fetch_cmd.zipapp_dir` to a `tempfile`
+dir and `os.chdir` there, so nothing touches the real missions folder.
+
+**Fake a GitHub archive** by building a zip whose entries live under a top-level
+`Repo-main/` folder (`unzip_exclude` strips that first component) — see
+`_make_github_archive` / `_fake_curl_writes_zip`.
+
+## What's covered
+
+- `curlretrieve`: success, HTTP error (404), missing curl, `-f` present.
+- `unzip_exclude`: strips the top folder, honors excludes.
+- `fetch_cmd` (issue #1 regression): a failed download **and** a non-zip payload
+  each leave **no folder** behind; a real zip extracts correctly.

--- a/tests/_bootstrap.py
+++ b/tests/_bootstrap.py
@@ -1,0 +1,12 @@
+"""Shared test bootstrap.
+
+The ``src`` modules use flat absolute imports (``from file_help import ...``),
+so ``src`` must be on ``sys.path`` before any of them can be imported. Import
+this module first in every test file.
+"""
+import os
+import sys
+
+_SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)

--- a/tests/test_fetch_cmd.py
+++ b/tests/test_fetch_cmd.py
@@ -1,0 +1,100 @@
+"""Tests for fetch_cmd -- the issue #1 regression: a bad repo name must NOT
+leave a folder behind.
+
+Mocking strategy: ``curlretrieve`` is patched *in the fetch_cmd namespace*
+(where it is looked up, per ``from file_help import curlretrieve``), so no real
+download happens. ``zipapp_dir`` is redirected to a temp dir and the CWD is set
+there too, because fetch cleans/creates folders relative to both.
+"""
+import _bootstrap  # noqa: F401  (adds ../src to sys.path)
+
+import io
+import os
+import shutil
+import tempfile
+import unittest
+import zipfile
+from unittest import mock
+
+import fetch_cmd
+
+
+def _fake_curl_writes_zip(url, localname):
+    """Stand-in for a successful download: writes a real github-style zip."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("Mission-main/story.mast", "== main ==\n")
+    with open(localname, "wb") as f:
+        f.write(buf.getvalue())
+    return True
+
+
+def _fake_curl_fails(url, localname):
+    """Stand-in for a 404: writes nothing, reports failure."""
+    return False
+
+
+def _fake_curl_writes_html(url, localname):
+    """Stand-in for the old broken behavior: curl 'succeeds' but the payload
+    is a GitHub 404 HTML page, not a zip."""
+    with open(localname, "wb") as f:
+        f.write(b"<html><body>404 Not Found</body></html>")
+    return True
+
+
+class FetchNoFolderOnBadUrlTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(self.tmp, ignore_errors=True))
+        self._old_cwd = os.getcwd()
+        os.chdir(self.tmp)
+        self.addCleanup(lambda: os.chdir(self._old_cwd))
+        # fetch cleans/creates under zipapp_dir; point it at the temp dir.
+        self._zip_patch = mock.patch.object(fetch_cmd, "zipapp_dir", self.tmp)
+        self._zip_patch.start()
+        self.addCleanup(self._zip_patch.stop)
+
+    def _run_fetch(self, repo):
+        # skip_libs=True so a successful path never tries to build libraries.
+        fetch_cmd.fetch_cmd(
+            repo=repo, user="artemis-sbs", branch="main", folder=None,
+            overwrite_libs=False, skip_libs=True, skip_clean=False,
+            overwrite_sbs_libs=True,
+        )
+
+    def test_download_failure_creates_no_folder(self):
+        with mock.patch.object(fetch_cmd, "curlretrieve", _fake_curl_fails):
+            self._run_fetch("TypoRepo")
+        self.assertFalse(os.path.exists(os.path.join(self.tmp, "TypoRepo")))
+        self.assertFalse(os.path.exists(os.path.join(self.tmp, "rel.zip")))
+
+    def test_non_zip_payload_creates_no_folder(self):
+        with mock.patch.object(fetch_cmd, "curlretrieve", _fake_curl_writes_html):
+            self._run_fetch("TypoRepo")
+        self.assertFalse(os.path.exists(os.path.join(self.tmp, "TypoRepo")))
+        self.assertFalse(os.path.exists(os.path.join(self.tmp, "rel.zip")))
+
+    def test_success_extracts_mission(self):
+        with mock.patch.object(fetch_cmd, "curlretrieve", _fake_curl_writes_zip):
+            self._run_fetch("Mission")
+        story = os.path.join(self.tmp, "Mission", "story.mast")
+        self.assertTrue(os.path.isfile(story))
+        # download artifact cleaned up
+        self.assertFalse(os.path.exists(os.path.join(self.tmp, "rel.zip")))
+
+    def test_cli_bad_url_no_folder(self):
+        # Same regression, but through the real Click command (prompt skipped
+        # with -q, library build skipped with -sl). No network: curl is mocked.
+        from click.testing import CliRunner
+        from cli_cmd import cli
+
+        runner = CliRunner()
+        with mock.patch.object(fetch_cmd, "curlretrieve", _fake_curl_fails):
+            result = runner.invoke(cli, ["fetch", "TypoRepo", "-q", "-sl"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("BAD MISSION URL", result.output)
+        self.assertFalse(os.path.exists(os.path.join(self.tmp, "TypoRepo")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_file_help.py
+++ b/tests/test_file_help.py
@@ -1,0 +1,86 @@
+"""Tests for file_help: curlretrieve (mocked subprocess) and unzip_exclude.
+
+No real network / no real curl is invoked -- subprocess.run is mocked, and
+unzip_exclude is exercised against an in-memory zip written to a temp dir.
+"""
+import _bootstrap  # noqa: F401  (adds ../src to sys.path)
+
+import io
+import os
+import subprocess
+import tempfile
+import unittest
+import zipfile
+from unittest import mock
+
+import file_help
+
+
+class CurlRetrieveTests(unittest.TestCase):
+    def test_returns_true_on_success(self):
+        fake = mock.Mock(returncode=0, stdout="", stderr="")
+        with mock.patch.object(subprocess, "run", return_value=fake) as run:
+            ok = file_help.curlretrieve("http://example/x.zip", "out.zip")
+        self.assertTrue(ok)
+        run.assert_called_once()
+
+    def test_passes_fail_flag(self):
+        # -f/--fail is what makes curl exit non-zero on a 404 instead of
+        # writing GitHub's HTML error page to disk (issue #1).
+        fake = mock.Mock(returncode=0, stdout="", stderr="")
+        with mock.patch.object(subprocess, "run", return_value=fake) as run:
+            file_help.curlretrieve("http://example/x.zip", "out.zip")
+        argv = run.call_args.args[0]
+        self.assertIn("-f", argv)
+
+    def test_returns_false_on_http_error(self):
+        err = subprocess.CalledProcessError(22, ["curl"], stderr="404")
+        with mock.patch.object(subprocess, "run", side_effect=err):
+            ok = file_help.curlretrieve("http://example/missing.zip", "out.zip")
+        self.assertFalse(ok)
+
+    def test_returns_false_when_curl_missing(self):
+        with mock.patch.object(subprocess, "run", side_effect=FileNotFoundError()):
+            ok = file_help.curlretrieve("http://example/x.zip", "out.zip")
+        self.assertFalse(ok)
+
+
+def _make_github_archive():
+    """Build an in-memory zip shaped like a GitHub archive.
+
+    GitHub wraps everything in a top-level ``<repo>-<branch>/`` folder that
+    unzip_exclude is expected to strip.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("Repo-main/story.mast", "== main ==\n")
+        zf.writestr("Repo-main/media/note.txt", "hi")
+        zf.writestr("Repo-main/.github/workflows/ci.yml", "jobs: {}")
+    buf.seek(0)
+    return buf.read()
+
+
+class UnzipExcludeTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, ignore_errors=True))
+        self.zip_path = os.path.join(self.tmp, "rel.zip")
+        with open(self.zip_path, "wb") as f:
+            f.write(_make_github_archive())
+
+    def test_strips_top_folder(self):
+        dest = os.path.join(self.tmp, "dest")
+        file_help.unzip_exclude(self.zip_path, dest, exclude_files=[])
+        # top-level "Repo-main/" is removed: files land directly under dest
+        self.assertTrue(os.path.isfile(os.path.join(dest, "story.mast")))
+        self.assertTrue(os.path.isfile(os.path.join(dest, "media", "note.txt")))
+
+    def test_honors_excludes(self):
+        dest = os.path.join(self.tmp, "dest")
+        file_help.unzip_exclude(self.zip_path, dest, exclude_files=[".github/"])
+        self.assertFalse(os.path.exists(os.path.join(dest, ".github")))
+        self.assertTrue(os.path.isfile(os.path.join(dest, "story.mast")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1.

## Problem
A typo in `sbs fetch <name>` left an empty folder behind, which the user then had to delete by hand.

## Root cause (three compounding bugs)
- `curlretrieve` ran `curl` **without `--fail`**, so a 404 exited `0` and wrote GitHub's HTML error page into `rel.zip` — indistinguishable from success.
- `curlretrieve` **swallowed** `CalledProcessError` and returned `None`, so the caller's `BAD MISSION URL` guard was dead code.
- `unzip_exclude`'s first action is `os.makedirs()`, so the folder was created **before** `zipfile` threw `BadZipFile` on the HTML.

## Fix
- `curl` now uses `-f`; `curlretrieve` returns a `bool`.
- `fetch_cmd` validates the download succeeded **and** is a real zip (`zipfile.is_zipfile`) **before** cleaning/creating any folder, and removes the stray download on failure.

## Tests
Adds a stdlib `unittest` suite (no new deps) that mocks `curl`/`subprocess` instead of downloading:
- `curlretrieve` return values + `-f` flag present
- `unzip_exclude` top-folder stripping / excludes
- issue #1 regression: a failed download **and** a non-zip payload each leave **no folder**; a real zip extracts correctly

Run: `python -m unittest discover -s tests` → 10 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)